### PR TITLE
refactor: replace dynamic_cast with safe casting methods

### DIFF
--- a/main/assets.cc
+++ b/main/assets.cc
@@ -344,8 +344,7 @@ bool Assets::LvglStrategy::Apply(Assets* assets) {
     cJSON* hide_subtitle = cJSON_GetObjectItem(root, "hide_subtitle");
     if (cJSON_IsBool(hide_subtitle)) {
         bool hide = cJSON_IsTrue(hide_subtitle);
-        auto lcd_display = dynamic_cast<LcdDisplay*>(display);
-        if (lcd_display != nullptr) {
+        if (auto lcd_display = display->AsLcdDisplay()) {
             lcd_display->SetHideSubtitle(hide);
             ESP_LOGI(TAG, "Set hide_subtitle to %s", hide ? "true" : "false");
         }
@@ -364,8 +363,7 @@ bool Assets::EmoteStrategy::InitializePartition(Assets* assets) {
     }
 
     esp_err_t ret = ESP_ERR_INVALID_STATE;
-    auto display = Board::GetInstance().GetDisplay();
-    auto* emote_display = dynamic_cast<emote::EmoteDisplay*>(display);
+    auto emote_display = Board::GetInstance().GetDisplay()->AsEmoteDisplay();
     if (emote_display && emote_display->GetEmoteHandle() != nullptr) {
         const emote_data_t data = {
             .type = EMOTE_SOURCE_PARTITION,
@@ -385,27 +383,26 @@ bool Assets::EmoteStrategy::InitializePartition(Assets* assets) {
 }
 
 void Assets::EmoteStrategy::UnApplyPartition(Assets* assets) {
-    auto display = Board::GetInstance().GetDisplay();
-    auto* emote_display = dynamic_cast<emote::EmoteDisplay*>(display);
-    if (emote_display && emote_display->GetEmoteHandle() != nullptr) {
-        emote_unmount_assets(emote_display->GetEmoteHandle());
+    if (auto emote_display = Board::GetInstance().GetDisplay()->AsEmoteDisplay()) {
+        if (emote_display->GetEmoteHandle() != nullptr) {
+            emote_unmount_assets(emote_display->GetEmoteHandle());
+        }
     }
     (void)assets; // Unused parameter
 }
 
 bool Assets::EmoteStrategy::GetAssetData(Assets* assets, const std::string& name, void*& ptr, size_t& size) {
-    auto display = Board::GetInstance().GetDisplay();
-    auto* emote_display = dynamic_cast<emote::EmoteDisplay*>(display);
-    if (emote_display && emote_display->GetEmoteHandle() != nullptr) {
-        const uint8_t* data = nullptr;
-        size_t data_size = 0;
-        if (ESP_OK == emote_get_asset_data_by_name(emote_display->GetEmoteHandle(), name.c_str(), &data, &data_size)) {
-            ptr = const_cast<void*>(static_cast<const void*>(data));
-            size = data_size;
-            return true;
+    if (auto emote_display = Board::GetInstance().GetDisplay()->AsEmoteDisplay()) {
+        if (emote_display->GetEmoteHandle() != nullptr) {
+            const uint8_t* data = nullptr;
+            size_t data_size = 0;
+            if (ESP_OK == emote_get_asset_data_by_name(emote_display->GetEmoteHandle(), name.c_str(), &data, &data_size)) {
+                ptr = const_cast<void*>(static_cast<const void*>(data));
+                size = data_size;
+                return true;
+            }
+            ESP_LOGE(TAG, "Failed to get asset data by name: %s", name.c_str());
         }
-        ESP_LOGE(TAG, "Failed to get asset data by name: %s", name.c_str());
-        return false;
     }
     (void)assets; // Unused parameter
     return false;
@@ -414,11 +411,10 @@ bool Assets::EmoteStrategy::GetAssetData(Assets* assets, const std::string& name
 bool Assets::EmoteStrategy::Apply(Assets* assets) {
     Assets::LoadSrmodelsFromIndex(assets);
 
-    auto display = Board::GetInstance().GetDisplay();
-    auto* emote_display = dynamic_cast<emote::EmoteDisplay*>(display);
-
-    if (emote_display && emote_display->GetEmoteHandle() != nullptr) {
-        emote_load_assets(emote_display->GetEmoteHandle());
+    if (auto emote_display = Board::GetInstance().GetDisplay()->AsEmoteDisplay()) {
+        if (emote_display->GetEmoteHandle() != nullptr) {
+            emote_load_assets(emote_display->GetEmoteHandle());
+        }
     }
     return true;
 }

--- a/main/audio/audio_service.cc
+++ b/main/audio/audio_service.cc
@@ -727,7 +727,7 @@ void AudioService::SetModelsList(srmodel_list_t* models_list) {
 
 bool AudioService::IsAfeWakeWord() {
 #if CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4
-    return wake_word_ != nullptr && dynamic_cast<AfeWakeWord*>(wake_word_.get()) != nullptr;
+    return wake_word_ != nullptr && wake_word_->IsAfeWakeWord();
 #else
     return false;
 #endif

--- a/main/audio/wake_word.h
+++ b/main/audio/wake_word.h
@@ -11,7 +11,10 @@
 class WakeWord {
 public:
     virtual ~WakeWord() = default;
-    
+
+    // Type checking method (for safe casting without RTTI)
+    virtual bool IsAfeWakeWord() const { return false; }
+
     virtual bool Initialize(AudioCodec* codec, srmodel_list_t* models_list) = 0;
     virtual void Feed(const std::vector<int16_t>& data) = 0;
     virtual void OnWakeWordDetected(std::function<void(const std::string& wake_word)> callback) = 0;

--- a/main/audio/wake_words/afe_wake_word.h
+++ b/main/audio/wake_words/afe_wake_word.h
@@ -24,6 +24,8 @@ public:
     AfeWakeWord();
     ~AfeWakeWord();
 
+    bool IsAfeWakeWord() const override { return true; }
+
     bool Initialize(AudioCodec* codec, srmodel_list_t* models_list);
     void Feed(const std::vector<int16_t>& data);
     void OnWakeWordDetected(std::function<void(const std::string& wake_word)> callback);

--- a/main/boards/common/board.cc
+++ b/main/boards/common/board.cc
@@ -159,7 +159,7 @@ std::string Board::GetSystemInfoJson() {
     auto display = GetDisplay();
     if (display) {
         json += R"("display":{)";
-        if (dynamic_cast<OledDisplay*>(display)) {
+        if (display->IsOledDisplay()) {
             json += R"("monochrome":)" + std::string("true") + R"(,)";
         } else {
             json += R"("monochrome":)" + std::string("false") + R"(,)";

--- a/main/boards/common/esp32_camera.cc
+++ b/main/boards/common/esp32_camera.cc
@@ -111,8 +111,7 @@ bool Esp32Camera::Capture() {
         uint8_t *preview_data = (uint8_t *)heap_caps_malloc(data_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
         if (preview_data != nullptr) {
             memcpy(preview_data, encode_buf_, data_size);
-            auto display = dynamic_cast<LvglDisplay *>(Board::GetInstance().GetDisplay());
-            if (display != nullptr) {
+            if (auto display = Board::GetInstance().GetDisplay()->AsLvglDisplay()) {
                 display->SetPreviewImage(std::make_unique<LvglAllocatedImage>(preview_data, data_size, current_fb_->width, current_fb_->height, current_fb_->width * 2, LV_COLOR_FORMAT_RGB565));
             } else {
                 heap_caps_free(preview_data);

--- a/main/boards/common/esp_video.cc
+++ b/main/boards/common/esp_video.cc
@@ -730,8 +730,7 @@ bool EspVideo::Capture() {
     }
 
     // 显示预览图片
-    auto display = dynamic_cast<LvglDisplay*>(Board::GetInstance().GetDisplay());
-    if (display != nullptr) {
+    if (auto display = Board::GetInstance().GetDisplay()->AsLvglDisplay()) {
         if (!frame_.data) {
             ESP_LOGE(TAG, "frame.data is null");
             return false;

--- a/main/boards/sensecap-watcher/sscma_camera.cc
+++ b/main/boards/sensecap-watcher/sscma_camera.cc
@@ -630,8 +630,7 @@ bool SscmaCamera::Capture() {
     }
 
     // 显示预览图片
-    auto display = dynamic_cast<LvglDisplay*>(Board::GetInstance().GetDisplay());
-    if (display != nullptr) {
+    if (auto display = Board::GetInstance().GetDisplay()->AsLvglDisplay()) {
         uint16_t w = preview_image_.header.w;
         uint16_t h = preview_image_.header.h;
         size_t image_size = w * h * 2;

--- a/main/display/display.h
+++ b/main/display/display.h
@@ -15,6 +15,12 @@
 #include <string>
 #include <chrono>
 
+// Forward declarations for safe casting return types
+class LvglDisplay;
+class OledDisplay;
+class LcdDisplay;
+namespace emote { class EmoteDisplay; }
+
 class Theme {
 public:
     Theme(const std::string& name) : name_(name) {}
@@ -47,6 +53,22 @@ public:
     inline int width() const { return width_; }
     inline int height() const { return height_; }
     inline bool IsSetupUICalled() const { return setup_ui_called_; }
+
+    // Type checking methods (for boolean checks)
+    virtual bool IsLvglDisplay() const { return false; }
+    virtual bool IsOledDisplay() const { return false; }
+    virtual bool IsLcdDisplay() const { return false; }
+    virtual bool IsEmoteDisplay() const { return false; }
+
+    // Safe casting methods - returns nullptr if type doesn't match
+    virtual class LvglDisplay* AsLvglDisplay() { return nullptr; }
+    virtual const class LvglDisplay* AsLvglDisplay() const { return nullptr; }
+    virtual class OledDisplay* AsOledDisplay() { return nullptr; }
+    virtual const class OledDisplay* AsOledDisplay() const { return nullptr; }
+    virtual class LcdDisplay* AsLcdDisplay() { return nullptr; }
+    virtual const class LcdDisplay* AsLcdDisplay() const { return nullptr; }
+    virtual class emote::EmoteDisplay* AsEmoteDisplay() { return nullptr; }
+    virtual const class emote::EmoteDisplay* AsEmoteDisplay() const { return nullptr; }
 
 protected:
     int width_ = 0;

--- a/main/display/emote_display.h
+++ b/main/display/emote_display.h
@@ -14,6 +14,10 @@ public:
     EmoteDisplay(esp_lcd_panel_handle_t panel, esp_lcd_panel_io_handle_t panel_io, int width, int height);
     virtual ~EmoteDisplay();
 
+    bool IsEmoteDisplay() const override { return true; }
+    emote::EmoteDisplay* AsEmoteDisplay() override { return this; }
+    const emote::EmoteDisplay* AsEmoteDisplay() const override { return this; }
+
     virtual void SetEmotion(const char* emotion) override;
     virtual void SetStatus(const char* status) override;
     virtual void SetChatMessage(const char* role, const char* content) override;

--- a/main/display/lcd_display.h
+++ b/main/display/lcd_display.h
@@ -46,6 +46,11 @@ protected:
     
 public:
     ~LcdDisplay();
+
+    bool IsLcdDisplay() const override { return true; }
+    LcdDisplay* AsLcdDisplay() override { return this; }
+    const LcdDisplay* AsLcdDisplay() const override { return this; }
+
     virtual void SetEmotion(const char* emotion) override;
     virtual void SetChatMessage(const char* role, const char* content) override;
     virtual void ClearChatMessages() override;

--- a/main/display/lvgl_display/lvgl_display.h
+++ b/main/display/lvgl_display/lvgl_display.h
@@ -17,6 +17,10 @@ public:
     LvglDisplay();
     virtual ~LvglDisplay();
 
+    bool IsLvglDisplay() const override { return true; }
+    LvglDisplay* AsLvglDisplay() override { return this; }
+    const LvglDisplay* AsLvglDisplay() const override { return this; }
+
     virtual void SetStatus(const char* status);
     virtual void ShowNotification(const char* notification, int duration_ms = 3000);
     virtual void ShowNotification(const std::string &notification, int duration_ms = 3000);

--- a/main/display/oled_display.h
+++ b/main/display/oled_display.h
@@ -32,6 +32,10 @@ public:
     OledDisplay(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_handle_t panel, int width, int height, bool mirror_x, bool mirror_y);
     ~OledDisplay();
 
+    bool IsOledDisplay() const override { return true; }
+    OledDisplay* AsOledDisplay() override { return this; }
+    const OledDisplay* AsOledDisplay() const override { return this; }
+
     virtual void SetupUI() override;
     virtual void SetChatMessage(const char* role, const char* content) override;
     virtual void SetEmotion(const char* emotion) override;

--- a/main/mcp_server.cc
+++ b/main/mcp_server.cc
@@ -170,15 +170,14 @@ void McpServer::AddUserOnlyTools() {
 
     // Display control
 #ifdef HAVE_LVGL
-    auto display = dynamic_cast<LvglDisplay*>(Board::GetInstance().GetDisplay());
-    if (display) {
+    if (auto display = Board::GetInstance().GetDisplay()->AsLvglDisplay()) {
         AddUserOnlyTool("self.screen.get_info", "Information about the screen, including width, height, etc.",
             PropertyList(),
             [display](const PropertyList& properties) -> ReturnValue {
                 cJSON *json = cJSON_CreateObject();
                 cJSON_AddNumberToObject(json, "width", display->width());
                 cJSON_AddNumberToObject(json, "height", display->height());
-                if (dynamic_cast<OledDisplay*>(display)) {
+                if (display->IsOledDisplay()) {
                     cJSON_AddBoolToObject(json, "monochrome", true);
                 } else {
                     cJSON_AddBoolToObject(json, "monochrome", false);


### PR DESCRIPTION
Add virtual type-checking methods (IsXxx/AsXxx) to Display and WakeWord base classes to avoid RTTI dependency. This provides a cleaner and more efficient way to check and cast between derived types.